### PR TITLE
MDR32F9Qx: don't inline EEPROM programming functions

### DIFF
--- a/MDR1986BE4_StdPeriph_Driver/inc/MDR32F9Qx_eeprom.h
+++ b/MDR1986BE4_StdPeriph_Driver/inc/MDR32F9Qx_eeprom.h
@@ -94,7 +94,7 @@ extern "C" {
 #elif defined ( __CC_ARM )
   #define __RAMFUNC
 #elif defined ( __GNUC__ )
-  #define __RAMFUNC       __attribute__((section(".ramfunc")))
+  #define __RAMFUNC       __attribute__((section(".ramfunc"))) __attribute__((__noinline__))
 #endif
 
 #if defined ( __GNUC__ )

--- a/MDR32F9Qx_StdPeriph_Driver/inc/MDR32F9Qx_eeprom.h
+++ b/MDR32F9Qx_StdPeriph_Driver/inc/MDR32F9Qx_eeprom.h
@@ -96,7 +96,7 @@ extern "C" {
 #elif defined ( __CC_ARM )
   #define __RAMFUNC
 #elif defined ( __GNUC__ )
-  #define __RAMFUNC       __attribute__((section(".ramfunc")))
+  #define __RAMFUNC       __attribute__((section(".ramfunc"))) __attribute__((__noinline__))
 #endif
 
 #if defined ( __GNUC__ )


### PR DESCRIPTION
it some cases GCC decided to inline EEPROM programming functions, that
results in non-working firmware.

Tested with arm-none-eabi-gcc (GNU Tools for ARM Embedded Processors)
5.4.1 20160919 (release) [ARM/embedded-5-branch revision 240496]

Here are parts from *.lss files showing missing empty .ramfunc section
without 'noinline' attribute. Pay attention to size of .ramfunc section.

[-------------------- no 'noinline' attribute ----------------------]
Sections:
Idx Name          Size      VMA       LMA       File off  Algn
  0 .eeprom       00000000  f0000000  f0000000  00011736  2**0
                  CONTENTS
  1 .text         00001736  00000000  00000000  00010000  2**4
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  2 .text.align   00000002  00001736  00001736  00011736  2**0
                  ALLOC, CODE
  3 .data         00000000  20000000  20000000  00011736  2**0
                  CONTENTS, ALLOC, LOAD, DATA
  4 .ramfunc      00000000  20100000  20100000  00011736  2**0
                  CONTENTS

[-------------------- with 'noinline' attribute ----------------------]
Sections:
Idx Name          Size      VMA       LMA       File off  Algn
  0 .eeprom       00000000  f0000000  f0000000  000201cc  2**0
                  CONTENTS
  1 .text         0000155a  00000000  00000000  00010000  2**4
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  2 .text.align   00000006  0000155a  0000155a  0001155a  2**0
                  ALLOC, CODE
  3 .data         00000000  20000000  20000000  000201cc  2**0
                  CONTENTS, ALLOC, LOAD, DATA
  4 .ramfunc      000001cc  20100000  00001560  00020000  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, CODE